### PR TITLE
Downgrading yarn

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,3 @@
 nodeLinker: node-modules
 
-yarnPath: .yarn/releases/yarn-3.2.1.cjs
+yarnPath: .yarn/releases/yarn-1.22.1.cjs

--- a/package.json
+++ b/package.json
@@ -59,5 +59,5 @@
     "typescript": "4.6.3",
     "webpack-bundle-analyzer": "^4.5.0"
   },
-  "packageManager": "yarn@3.2.1"
+  "packageManager": "yarn@1.22.1"
 }


### PR DESCRIPTION
- Roling back on yarn's version because vercel only supports v1
